### PR TITLE
Return only product data by name and add test

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -906,15 +906,7 @@ def get_product_by_name(name):
     product = Product.query.filter(Product.name == name).first()
     if product is None:
         abort(404)
-
-    try:
-        product_json = product.to_json()
-        subcategories = Subcategory.query.filter(Subcategory.id.in_(product_json["subcategories"]))
-        c_ids = set(c.id for sc in subcategories for c in sc.categories)
-        product_json["categories"] = list(c_ids)
-        return product_json, 200
-    except:
-        return "Error occured", 500
+    return jsonify(product.to_json()), 200
 
 
 @app.route('/products', methods=['GET'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -881,8 +881,8 @@ def delete_product(p_id):
         return "Error occured", 500
 
 
-@app.route('/product/<string:name>', methods=['GET'])
-def get_product_by_name(name):
+@app.route('/product', methods=['GET'])
+def get_product_by_name():
     """
     Get Product by Name
     ---
@@ -890,7 +890,7 @@ def get_product_by_name(name):
         - Product
     description: Get a product by name.
     parameters:
-        - in: path
+        - in: query
           name: name
           required: true
           type: string
@@ -903,6 +903,10 @@ def get_product_by_name(name):
         500:
             description: Error occurred.
     """
+    name = request.args.get('name')
+    if not name:
+        abort(400, description="Missing required query parameter 'name'")
+
     product = Product.query.filter(Product.name == name).first()
     if product is None:
         abort(404)

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,5 +1,3 @@
-from urllib.parse import quote
-
 import pytest
 
 from app.models import Product
@@ -140,6 +138,10 @@ class TestProduct:
 
         not_found_resp = self.client.get("/product", query_string={"name": "Non existent product"})
         assert not_found_resp.status_code == 404
+
+    def test_get_product_by_name_missing_param_returns_400(self):
+        resp = self.client.get("/product")  # no query param
+        assert resp.status_code == 400
 
     @pytest.mark.parametrize(
         "get_headers, expected_code",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Product-by-name endpoint now accepts the name as a query parameter, returns raw product data (no derived category augmentation), responds 200 when found, 404 when not found, and 400 when the name parameter is missing; internal errors now surface as standard server errors.

* **Tests**
  * Added tests covering retrieval by URL-encoded names (including spaces/special characters) with correct id/name/description, plus a test for missing name returning 400.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->