### PR TITLE
Feature/detect duplicate name in put

### DIFF
--- a/app/migrated_routes/category.py
+++ b/app/migrated_routes/category.py
@@ -207,6 +207,12 @@ class CategoryById(MethodView):
             if (
                 isinstance(ie.orig, UniqueViolation)
                 and ie.orig.diag.constraint_name
+                == CategoryCollection._NAME_UNIQUE_CONSTRAINT.name
+            ):
+                abort(409, message="Category with this name already exists")
+            if (
+                isinstance(ie.orig, UniqueViolation)
+                and ie.orig.diag.constraint_name
                 == category_subcategory.primary_key.name
             ):
                 abort(409, message="Category and subcategory already linked")

--- a/app/migrated_routes/subcategory.py
+++ b/app/migrated_routes/subcategory.py
@@ -225,6 +225,12 @@ class SubcategoryById(MethodView):
             if (
                 isinstance(ie.orig, UniqueViolation)
                 and ie.orig.diag.constraint_name
+                == SubcategoryCollection._NAME_UNIQUE_CONSTRAINT.name
+            ):
+                abort(409, message="Subcategory with this name already exists")
+            if (
+                isinstance(ie.orig, UniqueViolation)
+                and ie.orig.diag.constraint_name
                 == category_subcategory.primary_key.name
             ):
                 abort(409, message="Subcategory and category already linked")

--- a/tests/test_category.py
+++ b/tests/test_category.py
@@ -75,12 +75,14 @@ class TestCategory:
         assert "B" in names
 
     def test_update_category(self, create_authenticated_headers, create_category):
-        headers = create_authenticated_headers()
-        response = create_category("OldName", headers=headers)
+        response = create_category("OldName")
         data = response.get_json()
         cat_id = data["id"]
+
         update_resp = self.client.put(
-            f"/categories/{cat_id}", json={"name": "NewName"}, headers=headers
+            f"/categories/{cat_id}",
+            json={"name": "NewName"},
+            headers=create_authenticated_headers(),
         )
 
         assert update_resp.status_code == 200
@@ -112,11 +114,13 @@ class TestCategory:
         self._verify_category_in_db("NewName")
 
     def test_delete_category(self, create_authenticated_headers, create_category):
-        headers = create_authenticated_headers()
-        response = create_category("ToDelete", headers=headers)
+        response = create_category("ToDelete")
         data = response.get_json()
         cat_id = data["id"]
-        delete_resp = self.client.delete(f"/categories/{cat_id}", headers=headers)
+
+        delete_resp = self.client.delete(
+            f"/categories/{cat_id}", headers=create_authenticated_headers()
+        )
 
         assert delete_resp.status_code == 204
         get_resp = self.client.get(f"/categories/{cat_id}")

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -71,12 +71,14 @@ class TestProduct:
         assert "B" in names
 
     def test_update_product(self, create_authenticated_headers, create_product):
-        headers = create_authenticated_headers()
-        response = create_product("OldProduct", "OldDesc", headers=headers)
+        response = create_product("OldProduct", "OldDesc")
         data = response.get_json()
         p_id = data["id"]
+
         update_resp = self.client.put(
-            f"/product/{p_id}/update", json={"name": "NewProduct", "description": "NewDesc"}, headers=headers
+            f"/product/{p_id}/update",
+            json={"name": "NewProduct", "description": "NewDesc"},
+            headers=create_authenticated_headers(),
         )
 
         assert update_resp.status_code == 201
@@ -88,11 +90,13 @@ class TestProduct:
         self._verify_product_in_db("OldProduct", should_exist=False)
 
     def test_delete_product(self, create_authenticated_headers, create_product):
-        headers = create_authenticated_headers()
-        response = create_product("ToDelete", "desc", headers=headers)
+        response = create_product("ToDelete", "desc")
         data = response.get_json()
         p_id = data["id"]
-        delete_resp = self.client.delete(f"/product/{p_id}", headers=headers)
+
+        delete_resp = self.client.delete(
+            f"/product/{p_id}", headers=create_authenticated_headers()
+        )
 
         assert delete_resp.status_code == 200
         get_resp = self.client.get(f"/product/{p_id}")

--- a/tests/test_subcategory.py
+++ b/tests/test_subcategory.py
@@ -75,12 +75,14 @@ class TestSubcategory:
         assert "B" in names
 
     def test_update_subcategory(self, create_authenticated_headers, create_subcategory):
-        headers = create_authenticated_headers()
-        response = create_subcategory("OldSubcat", headers=headers)
+        response = create_subcategory("OldSubcat")
         data = response.get_json()
         sc_id = data["id"]
+
         update_resp = self.client.put(
-            f"/subcategories/{sc_id}", json={"name": "NewSubcat"}, headers=headers
+            f"/subcategories/{sc_id}",
+            json={"name": "NewSubcat"},
+            headers=create_authenticated_headers(),
         )
 
         assert update_resp.status_code == 200
@@ -111,11 +113,13 @@ class TestSubcategory:
         self._verify_subcategory_in_db("NewSubcat")
 
     def test_delete_subcategory(self, create_authenticated_headers, create_subcategory):
-        headers = create_authenticated_headers()
-        response = create_subcategory("ToDelete", headers=headers)
+        response = create_subcategory("ToDelete")
         data = response.get_json()
         sc_id = data["id"]
-        delete_resp = self.client.delete(f"/subcategories/{sc_id}", headers=headers)
+
+        delete_resp = self.client.delete(
+            f"/subcategories/{sc_id}", headers=create_authenticated_headers()
+        )
 
         assert delete_resp.status_code == 204
         get_resp = self.client.get(f"/subcategories/{sc_id}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer API responses: Updating categories or subcategories to an existing name now returns 409 Conflict with a specific message.

- Bug Fixes
  - Consistent conflict handling on updates, aligning with create behavior while preserving existing linkage conflict responses.

- Tests
  - Added tests covering duplicate-name update conflicts for categories and subcategories.
  - Streamlined auth handling in tests: creation calls unauthenticated; update/delete provide headers inline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->